### PR TITLE
drop extra configurations

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,18 +1,7 @@
 {
     "name": "mpi",
     "authors": ["Jude Young", "John Colvin"],
-    
-    "configurations": [
-        {
-            "name": "default",
-            "targetType": "sourceLibrary"
-        },
-        {
-            "name": "docs",
-            "targetType": "library",
-            "sourcePaths": ["."]
-        }
-    ],
+
     "buildTypes": {
         "travis": {
             "libs": ["mpi"]


### PR DESCRIPTION
same again, we can go back to sourceLibrary when we drop dub 0.9.23
